### PR TITLE
rosenthal: wlroots: Support elogind.

### DIFF
--- a/rosenthal/packages/wm.scm
+++ b/rosenthal/packages/wm.scm
@@ -55,7 +55,6 @@
       (propagated-inputs
        (modify-inputs (package-propagated-inputs base)
          (append libdrm-2.4.114)
-         (replace "libseat" libseat-sans-logind)
          (replace "libxkbcommon" libxkbcommon-minimal)
          (replace "pixman" pixman-0.42.2)
          (replace "wayland" wayland-1.21.0)


### PR DESCRIPTION
* rosenthal/packages/wm.scm (wlroots-0.16.0)[propagated-inputs]: Replace libseat to the one with elogind support.