### PR TITLE
Added xdg-desktop-portal-hyprland and helper

### DIFF
--- a/rosenthal/packages/freedesktop.scm
+++ b/rosenthal/packages/freedesktop.scm
@@ -46,3 +46,46 @@
                 (sha256
                  (base32
                   "0f72359fzvh6jzri4fd79m34rwm2r55p2ryq4306wrw7xliafzx0")))))))
+
+(define-public xdg-desktop-portal-hyprland
+  (package
+    (name "xdg-desktop-portal-hyprland")
+    (version "0.4.0")
+    (source (origin
+              (method git-fetch)
+              (uri (git-reference
+                     (url "https://github.com/hyprwm/xdg-desktop-portal-hyprland")
+                     (commit (string-append "v" version))))
+              (file-name (git-file-name name version))
+              (sha256
+                (base32
+                  "1dcglmx02j73qbmw9qsacamn8byakyzwknpqjnhsyphixb4crrdg"))))
+    (build-system meson-build-system)
+    (arguments
+      (list
+        #:configure-flags #~(list "-Dsystemd=disabled")))
+    (native-inputs (list cmake pkg-config wayland hyprland-protocols))
+    (inputs (list elogind hyprland-protocols pipewire wayland-protocols wayland libinih `(,util-linux "lib")))
+    (home-page "https://github.com/hyprwm/xdg-desktop-portal-hyprland")
+    (synopsis "@code{xdg-desktop-portal} backend for Hyprland")
+    (description
+      "This package provides @code{xdg-desktop-portal-hyprland}. This project extends @code{xdg-desktop-portal-wlr} for Hyprland, adding support for @code{xdg-desktop-portal} screenshot and casting interfaces while adding a few extra portals specific to Hyprland: mostly for window sharing. Requires @code{hyprland-share-picker}.")
+    (license license:expat)))
+
+(define-public hyprland-share-picker
+  (package
+    (inherit xdg-desktop-portal-hyprland)
+    (name "hyprland-share-picker")
+    (build-system qt-build-system)
+    (inputs (modify-inputs (package-inputs xdg-desktop-portal-hyprland)
+                           (append qtwayland-5)))
+    (native-inputs (modify-inputs (package-native-inputs xdg-desktop-portal-hyprland)
+                                  (append qtwayland-5)))
+    (arguments
+      (list
+        #:tests? #f
+        #:phases
+        #~(modify-phases %standard-phases
+            (add-after 'unpack 'chdir
+              (lambda _ (chdir "hyprland-share-picker"))))))
+    (synopsis "Helper program for @code{xdg-desktop-portal-hyprland}.")))

--- a/rosenthal/packages/freedesktop.scm
+++ b/rosenthal/packages/freedesktop.scm
@@ -78,7 +78,7 @@
     (name "hyprland-share-picker")
     (build-system qt-build-system)
     (inputs (modify-inputs (package-inputs xdg-desktop-portal-hyprland)
-                           (append qtwayland-5)))
+                           (append qtwayland-5 slurp)))
     (native-inputs (modify-inputs (package-native-inputs xdg-desktop-portal-hyprland)
                                   (append qtwayland-5)))
     (arguments


### PR DESCRIPTION
Added package definitions for `xdg-desktop-portal-hyprland` and its helper utility `hyprland-share-picker`. I've been using it for a little bit now and it seems to work properly (except region selecting, which seems to be an upstream issue.)

Open to comments, especially how I've set up the dependency chain. I wanted to have the selector tool inherit the `xdg-desktop-portal-hyprland` package (specifically the source definition, but adding the selector to the inputs of the portal caused a circular dependency of some kind and didn't allow the file to properly build, open to suggestions on how to handle that specifically.)

Any other comments as well regarding style and what-not, this is my first actual package definition, rather than updating something!