### PR TITLE
Add qtwayland to xdg-desktop-portal-hyprland inputs

### DIFF
--- a/rosenthal/packages/wm.scm
+++ b/rosenthal/packages/wm.scm
@@ -317,7 +317,8 @@ more.")
            hyprland-protocols
            mesa
            pipewire
-           qtbase-5
+           qtbase
+           qtwayland
            sdbus-c++
            slurp
            wayland-protocols))


### PR DESCRIPTION
hyprland-share-picker needs to have access to the qtwayland plugin to work, otherwise it crashes (for instance, when trying to screen share with obs).